### PR TITLE
BREAKING: Allow specifying configurations via Python scripts

### DIFF
--- a/multiversum/cli.py
+++ b/multiversum/cli.py
@@ -1,13 +1,10 @@
 import click
 from pathlib import Path
-import runpy
-from typing import Optional
 
 from .multiverse import DEFAULT_SEED, MultiverseAnalysis, add_ids_to_multiverse_grid
 from .logger import logger
 
 DEFAULT_CONFIG_FILE = "multiverse.toml"
-DEFAULT_PYTHON_SCRIPT_NAME = "multiverse.py"
 
 
 @click.command()
@@ -53,7 +50,6 @@ def cli(
     output_dir,
     seed,
     u_id,
-    dimensions: Optional[dict] = None,
     **kwargs,
 ):
     """Run a multiverse analysis from the command line."""
@@ -66,19 +62,7 @@ def cli(
     else:
         config_file = None
 
-    if config_file is None and dimensions is None:
-        # Check whether multiverse.py might exist and run it
-        if Path(DEFAULT_PYTHON_SCRIPT_NAME).is_file():
-            logger.info(
-                f"Detected {DEFAULT_PYTHON_SCRIPT_NAME}. Running it.\n"
-                f"Please create a {DEFAULT_CONFIG_FILE}, if you don't want to run the script."
-            )
-
-            runpy.run_path(DEFAULT_PYTHON_SCRIPT_NAME)
-            return
-
     multiverse_analysis = MultiverseAnalysis(
-        dimensions=dimensions,
         config_file=config_file,
         notebook=Path(notebook),
         output_dir=Path(output_dir),
@@ -130,28 +114,6 @@ def cli(
     multiverse_analysis.aggregate_data(save=True)
 
     multiverse_analysis.check_missing_universes()
-
-
-def run_cli(dimensions: Optional[dict] = None, **kwargs):
-    """Run a multiverse analysis from the command line.
-
-    You will only need to use this function if you want to directly pass in
-    dimensions from within Python (e.g. if you generate dimensions via code).
-
-    To run the CLI without providing dimensions, simply run
-    `python -m multiversum`.
-
-    Args:
-        dimensions (dict, optional): Manually specify dimensions. Set to None to
-            use normal default / allow specification as an argument.
-            Defaults to None.
-        **kwargs: Additional keyword arguments to pass to the MultiverseAnalysis
-
-    Raises:
-        FileNotFoundError: If the dimensions file is not found.
-        NotADirectoryError: If the output directory is not found.
-    """
-    cli(dimensions=dimensions, **kwargs)
 
 
 if __name__ == "__main__":

--- a/multiversum/cli.py
+++ b/multiversum/cli.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from .multiverse import DEFAULT_SEED, MultiverseAnalysis, add_ids_to_multiverse_grid
 from .logger import logger
 
-DEFAULT_CONFIG_FILE = "multiverse.toml"
+DEFAULT_CONFIG_FILES = ["multiverse.toml", "multiverse.json", "multiverse.py"]
 
 
 @click.command()
@@ -18,7 +18,7 @@ DEFAULT_CONFIG_FILE = "multiverse.toml"
     "--config",
     type=click.Path(exists=True),
     default=None,
-    help=f"Relative path to a TOML or JSON file with a config for the multiverse. Defaults to {DEFAULT_CONFIG_FILE}.",
+    help=f"Relative path to a TOML, JSON or Python file with a config for the multiverse. Defaults to searching for {', '.join(DEFAULT_CONFIG_FILES)} (in that order).",
 )
 @click.option(
     "--notebook",
@@ -50,17 +50,18 @@ def cli(
     output_dir,
     seed,
     u_id,
-    **kwargs,
 ):
     """Run a multiverse analysis from the command line."""
     logger.debug(f"Parsed arguments: {ctx.params}")
 
     if config is not None:
         config_file = Path(config)
-    elif Path(DEFAULT_CONFIG_FILE).is_file():
-        config_file = Path(DEFAULT_CONFIG_FILE)
     else:
         config_file = None
+        for file in DEFAULT_CONFIG_FILES:
+            if Path(file).is_file():
+                config_file = Path(file)
+                break
 
     multiverse_analysis = MultiverseAnalysis(
         config_file=config_file,
@@ -68,7 +69,6 @@ def cli(
         output_dir=Path(output_dir),
         new_run=(mode != "continue"),
         seed=seed,
-        **kwargs,
     )
 
     multiverse_grid = multiverse_analysis.generate_grid(save=True)

--- a/multiversum/multiverse.py
+++ b/multiversum/multiverse.py
@@ -4,6 +4,7 @@ This module contains helper functions to orchestrate a multiverse analysis.
 
 import itertools
 from pathlib import Path
+import runpy
 from typing import Any, Dict, List, Optional, TypedDict
 from hashlib import md5
 import subprocess
@@ -135,9 +136,11 @@ class MultiverseAnalysis:
         Args:
             dimensions: A dictionary containing the dimensions of the multiverse.
                 Each dimension corresponds to a decision.
-                Alternatively a Path to a JSON file containing the dimensions.
             notebook: The Path to the notebook to run.
-            config_file: A Path to a JSON file containing the dimensions.
+            config_file: A Path to a TOML, JSON or Python file containing the
+                analysis configuration. Supported confugration options are:
+                dimensions, stop_on_error. If a Python file is used, it should
+                contain a dictionary named config.
             output_dir: The directory to store the output in.
             run_no: The number of the current run. Defaults to an automatically
                 incrementing integer number if new_run is True or the last run if
@@ -154,8 +157,13 @@ class MultiverseAnalysis:
             elif config_file.suffix == ".json":
                 with open(config_file, "r") as fp:
                     config = json.load(fp)
+            elif config_file.suffix == ".py":
+                results = runpy.run_path(str(config_file))
+                config = results["config"]
             else:
-                raise ValueError("Only .toml and .json files are supported as config.")
+                raise ValueError(
+                    "Only .toml, .json and .py files are supported as config."
+                )
 
             if "dimensions" in config:
                 assert dimensions is None

--- a/tests/notebooks/simple_c.py
+++ b/tests/notebooks/simple_c.py
@@ -1,0 +1,1 @@
+config = {"dimensions": {"x": ["C", "D"], "y": ["C", "D"]}}

--- a/tests/test_multiverse.py
+++ b/tests/test_multiverse.py
@@ -89,6 +89,15 @@ class TestMultiverseAnalysis:
             "y": ["B", "C"],
         }
 
+    def test_config_py(self):
+        mv = MultiverseAnalysis(
+            config_file=TEST_DIR / "notebooks" / "simple_c.py", run_no=0
+        )
+        assert mv.dimensions == {
+            "x": ["C", "D"],
+            "y": ["C", "D"],
+        }
+
     def test_noteboook_simple(self):
         output_dir = get_temp_dir("test_MultiverseAnalysis_noteboook_simple")
         mv = MultiverseAnalysis(


### PR DESCRIPTION
This fixes #5 but changes the previous behavior.

Previously the python script would only be executed and needed a call to run_cli() (the function has been removed in this PR in favor of specifying an explicit config dictionary).